### PR TITLE
miniwdl 1.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
-ARG MINIWDL_VERSION=1.1.4
+ARG MINIWDL_VERSION=1.1.5
 
 LABEL maintainer="IDseq Team idseq-tech@chanzuckerberg.com"
 

--- a/terraform/modules/swipe-sfn-batch-job/batch_job_container_properties.yml
+++ b/terraform/modules/swipe-sfn-batch-job/batch_job_container_properties.yml
@@ -35,14 +35,14 @@ command:
     put_metric MemoryInUse $(python3 -c 'import psutil; m=psutil.virtual_memory(); print(100*(1-m.available/m.total))');
     sleep 60;
     done &
-  - "mkdir -p /mnt/download_cache; touch /mnt/download_cache/.cleaner_lock"
+  - "mkdir -p /mnt/download_cache; touch /mnt/download_cache/_miniwdl_flock"
   - >-
     clean_wd() {
     (shopt -s nullglob;
     for wf_log in /mnt/20??????_??????_*/workflow.log; do
     flock -n $wf_log rm -rf $(dirname $wf_log) || true;
     done;
-    flock -x /mnt/download_cache/.cleaner_lock clean_download_cache.sh /mnt/download_cache $DOWNLOAD_CACHE_MAX_GB)
+    flock -x /mnt/download_cache/_miniwdl_flock clean_download_cache.sh /mnt/download_cache $DOWNLOAD_CACHE_MAX_GB)
     }
   - "clean_wd"
   - "df -h / /mnt"
@@ -67,7 +67,7 @@ command:
     fi
     }
   - "trap handle_error EXIT"
-  - 'miniwdl run --dir /mnt $(basename "$WDL_WORKFLOW_URI") --input wdl_input.json --verbose --error-json --log-json > wdl_output.json'
+  - 'miniwdl run --dir /mnt $(basename "$WDL_WORKFLOW_URI") --input wdl_input.json --verbose --log-json -o wdl_output.json'
   - "clean_wd"
 environment:
   - name: "WDL_INPUT_URI"


### PR DESCRIPTION
Applying this: https://github.com/chanzuckerberg/idseq/pull/313

Fixes an issue regarding failing with full cache when there is still space. Now exceeding the cache limit is a warning.