### PR TITLE
remove read output lambda

### DIFF
--- a/sfn-io-helper-lambda/app.py
+++ b/sfn-io-helper-lambda/app.py
@@ -55,14 +55,6 @@ def preprocess_input(sfn_data, context):
                                          state_machine_name=state_machine_name)
 
 
-@app.lambda_function("process-stage-output")
-def process_stage_output(sfn_data, context):
-    assert sfn_data["CurrentState"].endswith("ReadOutput")
-    sfn_state = stage_io.read_state_from_s3(sfn_state=sfn_data["Input"], current_state=sfn_data["CurrentState"])
-    sfn_state = stage_io.trim_batch_job_details(sfn_state=sfn_state)
-    return sfn_state
-
-
 @app.lambda_function("handle-success")
 def handle_success(sfn_data, context):
     sfn_state = sfn_data["Input"]

--- a/terraform/modules/swipe-sfn/sfn-templates/single-wdl-1.yml
+++ b/terraform/modules/swipe-sfn/sfn-templates/single-wdl-1.yml
@@ -36,7 +36,7 @@ States:
           - Name: SFN_CURRENT_STATE
             Value.$: $$.State.Name
     ResultPath: $.BatchJobDetails.Run
-    Next: RunReadOutput
+    Next: HandleSuccess
     Retry: &BatchRetryConfig
       - ErrorEquals: ["Batch.AWSBatchException"]
         IntervalSeconds: 15
@@ -58,7 +58,7 @@ States:
       - Variable: "$.BatchJobError.RunSPOT.Cause.StatusReason"
         StringMatches: "Host EC2 (instance i-*) terminated."
         Next: RunEC2
-    Default: RunReadOutput
+    Default: HandleFailure
   RunEC2:
     Type: Task
     Resource: arn:aws:states:::batch:submitJob.sync
@@ -71,22 +71,11 @@ States:
         Memory.$: $.RunEC2Memory
         Environment: *RunEnvironment
     ResultPath: $.BatchJobDetails.Run
-    Next: RunReadOutput
+    Next: HandleSuccess
     Retry: *BatchRetryConfig
     Catch:
       - ErrorEquals: ["States.ALL"]
         ResultPath: $.BatchJobError.RunEC2
-        Next: RunReadOutput
-  RunReadOutput:
-    Type: Task
-    Resource: arn:aws:states:::lambda:invoke
-    Parameters: &ReadOutputParameters
-      FunctionName: "swipe-${deployment_environment}-process-stage-output"
-      Payload: *PassthroughStatePayload
-    OutputPath: $.Payload
-    Next: HandleSuccess
-    Catch:
-      - ErrorEquals: ["States.ALL"]
         Next: HandleFailure
   HandleSuccess:
     Type: Task


### PR DESCRIPTION
Due to the error handling of smart retries this is no longer required. This removal also fixes a bug with smart retries. A version of: https://github.com/chanzuckerberg/idseq/pull/344.