### PR TITLE
Allow ec2 to assume this role for debugging.

### DIFF
--- a/terraform/modules/swipe-sfn-batch-job/main.tf
+++ b/terraform/modules/swipe-sfn-batch-job/main.tf
@@ -85,7 +85,7 @@ resource "aws_iam_policy" "swipe_batch_main_job" {
 resource "aws_iam_role" "swipe_batch_main_job" {
   name = "${var.app_name}-batch-job"
   assume_role_policy = templatefile("${path.module}/../../iam_policy_templates/trust_policy.json", {
-    trust_services = ["ecs-tasks"]
+    trust_services = ["ecs-tasks", "ec2"]
   })
   tags = var.tags
 }


### PR DESCRIPTION
We probably want to make this trust policy configurable in the future, but being able to attach this role to EC2 instances makes debugging/testing much simpler.