### PR TITLE
Make sfn timeout == batch job timeout

### DIFF
--- a/terraform/modules/swipe-sfn/default-wdl.yml
+++ b/terraform/modules/swipe-sfn/default-wdl.yml
@@ -21,7 +21,7 @@ States:
       JobName.$: $$.Execution.Name
       JobDefinition: &JobDefinition "${batch_job_definition_name}"
       Timeout: &RunBatchTimeout
-        AttemptDurationSeconds: 18000 # 5 hours
+        AttemptDurationSeconds: 86400 # 24 hours
       ContainerOverrides:
         Memory.$: $.RunSPOTMemory
         Environment: &RunEnvironment

--- a/terraform/modules/swipe-sfn/default-wdl.yml
+++ b/terraform/modules/swipe-sfn/default-wdl.yml
@@ -21,7 +21,7 @@ States:
       JobName.$: $$.Execution.Name
       JobDefinition: &JobDefinition "${batch_job_definition_name}"
       Timeout: &RunBatchTimeout
-        AttemptDurationSeconds: 86400 # 24 hours
+        AttemptDurationSeconds: ${batch_job_timeout_seconds}
       ContainerOverrides:
         Memory.$: $.RunSPOTMemory
         Environment: &RunEnvironment

--- a/terraform/modules/swipe-sfn/main.tf
+++ b/terraform/modules/swipe-sfn/main.tf
@@ -69,6 +69,7 @@ resource "aws_sfn_state_machine" "swipe_single_wdl" {
     batch_spot_job_queue_arn         = var.batch_spot_job_queue_arn,
     batch_on_demand_job_queue_arn    = var.batch_on_demand_job_queue_arn,
     batch_job_definition_name        = module.batch_job.batch_job_definition_name,
+    batch_job_timeout_seconds        = var.batch_job_timeout_seconds,
     preprocess_input_lambda_name     = module.sfn_io_helper.preprocess_input_lambda_name,
     process_stage_output_lambda_name = module.sfn_io_helper.process_stage_output_lambda_name,
     handle_success_lambda_name       = module.sfn_io_helper.handle_success_lambda_name,


### PR DESCRIPTION
The [batch job timeout](https://github.com/chanzuckerberg/swipe/blob/main/terraform/modules/swipe-sfn/variables.tf#L72-L76) is 24h, but the sfn timeout is only 5h. Let's synchronize them at least