### PR TITLE
update docker images and cache for faster tests

### DIFF
--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -42,8 +42,7 @@ jobs:
           docker pull ghcr.io/chanzuckerberg/swipe:latest
           docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
           docker-compose pull
-          scripts/run_mock_server.sh &
-          for i in {1..60}; do if timeout 1 bash -c "echo > /dev/tcp/localhost/9000"; then break; elif [[ $i == 60 ]]; then exit 1; else sleep 1; fi; done
+          docker-compose up -d
           make deploy-mock test
 
   terraform_format:

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           source scripts/init_ci_runner.sh
           source environment.test
+          docker pull --cache-from ghcr.io/chanzuckerberg/swipe:latest
           docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
           scripts/run_mock_server.sh &
           for i in {1..60}; do if timeout 1 bash -c "echo > /dev/tcp/localhost/9000"; then break; elif [[ $i == 60 ]]; then exit 1; else sleep 1; fi; done

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -41,6 +41,7 @@ jobs:
           source environment.test
           docker pull ghcr.io/chanzuckerberg/swipe:latest
           docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
+          docker-compose pull
           scripts/run_mock_server.sh &
           for i in {1..60}; do if timeout 1 bash -c "echo > /dev/tcp/localhost/9000"; then break; elif [[ $i == 60 ]]; then exit 1; else sleep 1; fi; done
           make deploy-mock test

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -39,9 +39,7 @@ jobs:
         run: |
           source scripts/init_ci_runner.sh
           source environment.test
-          # TODO: remove moto hack once change is merged
-          git clone https://github.com/morsecodist/moto.git ; cd moto ; git checkout tmorse-docker-networks ; docker build -t moto_local . ; cd .. ; rm -rf moto
-          docker build -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
+          docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
           scripts/run_mock_server.sh &
           for i in {1..60}; do if timeout 1 bash -c "echo > /dev/tcp/localhost/9000"; then break; elif [[ $i == 60 ]]; then exit 1; else sleep 1; fi; done
           make deploy-mock test

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source scripts/init_ci_runner.sh
           source environment.test
-          docker pull --cache-from ghcr.io/chanzuckerberg/swipe:latest
+          docker pull ghcr.io/chanzuckerberg/swipe:latest
           docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
           scripts/run_mock_server.sh &
           for i in {1..60}; do if timeout 1 bash -c "echo > /dev/tcp/localhost/9000"; then break; elif [[ $i == 60 ]]; then exit 1; else sleep 1; fi; done

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -42,7 +42,7 @@ jobs:
           docker pull ghcr.io/chanzuckerberg/swipe:latest
           docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
           docker-compose pull
-          docker-compose up -d
+          docker-compose up &
           make deploy-mock test
 
   terraform_format:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   motoserver:
     container_name: motoserver
-    image: motoserver/moto
+    image: motoserver/moto:3.0.2
     environment:
       - MOTO_DOCKER_NETWORK=awsnet
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   motoserver:
     container_name: motoserver
-    image: moto_local
+    image: motoserver/moto
     environment:
       - MOTO_DOCKER_NETWORK=awsnet
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.8"
 services:
   motoserver:
     container_name: motoserver
-    image: motoserver/moto:3.0.2
+    image: motoserver/moto
     environment:
-      - MOTO_DOCKER_NETWORK=awsnet
+      - MOTO_DOCKER_NETWORK_NAME=awsnet
+      - MOTO_DOCKER_NETWORK_MODE=overlay
     ports:
       - "9000:5000"
     volumes:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-awscli
 boto3
 flake8
 mypy

--- a/scripts/run_mock_server.sh
+++ b/scripts/run_mock_server.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-trap "exit" INT TERM
-trap "kill 0" EXIT
-
-docker-compose up


### PR DESCRIPTION
Takes tests from ~5 min to ~3 min and removes some ugly hacks.

- Moto accepted my changes so we can pull the official image which saves time and removes the ugly pull and build hack
- Pull and cache from latest docker image so tests that don't change the docker image will run much faster
- I realized that all we were waiting for with the `docker-compose up` was the image pulling so I could remove the weird detatch + poll thingy by blocking on the image pull, then just running `docker-compose up` and going straight to the tests. This also let me delete the script that was basically just one line