### PR TITLE
Simplify our setup/teardown workflows.

### DIFF
--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -39,7 +39,7 @@ jobs:
           docker pull ghcr.io/chanzuckerberg/swipe:latest
           make up
           sleep 1
-          make deploy-mock test
+          make test
 
   terraform_format:
     runs-on: ubuntu-20.04

--- a/.github/workflows/sfn-wdl-ci.yml
+++ b/.github/workflows/sfn-wdl-ci.yml
@@ -8,8 +8,6 @@ env:
   LANG: C.UTF-8
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   # These specific values are mandatory, they are sent to lambda hard coded
-  AWS_ACCESS_KEY_ID: role-account-id
-  AWS_SECRET_ACCESS_KEY: role-secret-key
   AWS_SESSION_TOKEN: session-token
   AWS_DEFAULT_REGION: us-east-1
 
@@ -38,11 +36,8 @@ jobs:
       - name: Run tests
         run: |
           source scripts/init_ci_runner.sh
-          source environment.test
           docker pull ghcr.io/chanzuckerberg/swipe:latest
-          docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$(cat version) .
-          docker-compose pull
-          docker-compose up &
+          make up
           sleep 1
           make deploy-mock test
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,24 @@
 SHELL=/bin/bash -o pipefail
 
 deploy-mock:
-	rm terraform.tfstate || true
-	aws ssm put-parameter --name /mock-aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --value ami-12345678 --type String --endpoint-url http://localhost:9000
-	cp test/mock.tf .; unset TF_CLI_ARGS_init; terraform init; TF_VAR_mock=true TF_VAR_app_name=swipe-test TF_VAR_batch_ec2_instance_types='["optimal"]' TF_VAR_call_cache=true TF_VAR_sqs_queues='{"notifications":{"dead_letter": false}}' TF_VAR_sfn_template_files='{"stage-test":"test/stage-test.yml"}' TF_VAR_stage_memory_defaults='{"Run": {"spot": 12800, "on_demand": 256000}, "One": {"spot": 12800, "on_demand": 256000}, "Two": {"spot": 12800, "on_demand": 256000}}' terraform apply --auto-approve
+	- source environment.test; aws ssm put-parameter --name /mock-aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id --value ami-12345678 --type String --endpoint-url http://localhost:9000
+	source environment.test; \
+	cp test/mock.tf .; \
+	unset TF_CLI_ARGS_init; \
+	terraform init; \
+	TF_VAR_mock=true TF_VAR_app_name=swipe-test TF_VAR_batch_ec2_instance_types='["optimal"]' TF_VAR_call_cache=true TF_VAR_sqs_queues='{"notifications":{"dead_letter": false}}' TF_VAR_sfn_template_files='{"stage-test":"test/stage-test.yml"}' TF_VAR_stage_memory_defaults='{"Run": {"spot": 12800, "on_demand": 256000}, "One": {"spot": 12800, "on_demand": 256000}, "Two": {"spot": 12800, "on_demand": 256000}}' terraform apply --auto-approve
+
+up: start deploy-mock
+
+start:
+	source environment.test; \
+	docker build --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$$(cat version) .; \
+	docker-compose up -d
+
+clean:
+	docker-compose down
+	docker-compose rm
+	rm -f terraform.tfstate terraform.tfstate.backup
 
 lint:
 	flake8 .
@@ -15,9 +30,20 @@ format:
 	terraform fmt --recursive .
 
 test:
-	python -m unittest discover .
+	source environment.test; \
+	python3 -m unittest discover .
 
 get-logs:
 	aegea logs --start-time=-5m --no-export /aws/lambda/$(app_name)
 
-.PHONY: deploy init-tf lint format test
+debug:
+	echo "Lambda Logs"
+	source environment.test; \
+	for i in $$(aws --endpoint-url http://localhost:9000 logs describe-log-groups | jq -r '.logGroups[].logGroupName'); do \
+		echo; \
+		echo; \
+		echo "Log group: $$i"; \
+		aws --endpoint-url http://localhost:9000 logs tail $$i; \
+	done;
+
+.PHONY: deploy up clean debug start init-tf lint format test

--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ pip install -r requirements.txt
 Bring up mock AWS infrastructure:
 
 ```bash
-docker-compose up -d
-source environment.test
-make deploy-mock
+make up
 ```
 
 Run the tests:

--- a/environment.test
+++ b/environment.test
@@ -1,2 +1,4 @@
+export AWS_ACCESS_KEY_ID=role-account-id
+export AWS_SECRET_ACCESS_KEY=role-secret-key
 export AWS_REGION=us-east-1
 export AWS_DEFAULT_REGION=us-east-1


### PR DESCRIPTION
Adds some convenience to our Makefile:
- Source the env file in our make targets so we don't have to re-run a pre-requisite in each terminal window
- Add a one-step `up` target that builds images, starts containers, and runs terraform
- Add a one-step `clean` target to clean up swipe test resources
- Add a `debug` target to get all cloudwatch logs to debug problems

Also update CI and docs to use the new targets