### PR TITLE
Clear SQS queues before running tests

### DIFF
--- a/test/test_wdl.py
+++ b/test/test_wdl.py
@@ -122,6 +122,9 @@ class TestSFNWDL(unittest.TestCase):
         ][0]
         self.state_change_queue_url = self.sqs.list_queues()["QueueUrls"][0]
 
+        # Empty the SQS queue before running tests.
+        _ = self.sqs.purge_queue(QueueUrl=self.state_change_queue_url)
+
     def tearDown(self) -> None:
         self.test_bucket.delete_objects(
             Delete={


### PR DESCRIPTION
If we ran tests against a given moto server once, subsequent tests were failing. This clears the queue before each test, and makes sure we're not receiving old/stale queue messages.