### PR TITLE
Add RunError as valid output to test

### DIFF
--- a/test/test_wdl.py
+++ b/test/test_wdl.py
@@ -258,7 +258,7 @@ class TestSFNWDL(unittest.TestCase):
         arn, description, messages = self._wait_sfn(sfn_input, self.single_sfn_arn, expect_success=False)
         errorType = (self.sfn.get_execution_history(executionArn=arn)["events"]
                      [-1]["executionFailedEventDetails"]["error"])
-        self.assertTrue(errorType in ["UncaughtError", "RunError"])
+        self.assertTrue(errorType in ["UncaughtError", "RunFailed"])
 
     def test_staged_sfn_wdl_workflow(self):
         output_prefix = "out-2"

--- a/test/test_wdl.py
+++ b/test/test_wdl.py
@@ -258,7 +258,7 @@ class TestSFNWDL(unittest.TestCase):
         arn, description, messages = self._wait_sfn(sfn_input, self.single_sfn_arn, expect_success=False)
         errorType = (self.sfn.get_execution_history(executionArn=arn)["events"]
                      [-1]["executionFailedEventDetails"]["error"])
-        self.assertEqual(errorType, "UncaughtError")
+        self.assertTrue(errorType in ["UncaughtError", "RunError"])
 
     def test_staged_sfn_wdl_workflow(self):
         output_prefix = "out-2"


### PR DESCRIPTION
We may have some sort of race condition, since both these errors will return in our tests. Technically both errors are examples of the workflow catching an unexpected failure so I'm ok with either. 