### PR TITLE
Unset defaults for S3 prefixes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -91,15 +91,13 @@ variable "job_policy_arns" {
 }
 
 variable "workspace_s3_prefix" {
-  description = "S3 prefix where input, output, and log files will be stored, read and write permissions will be granted for this prefix"
+  description = "S3 prefix (bucket-name/path) where input, output, and log files will be stored, read and write permissions will be granted for this prefix"
   type        = string
-  default     = ""
 }
 
 variable "wdl_workflow_s3_prefix" {
-  description = "S3 prefix where WDL workflows are stored, read permissions will be granted for this prefix"
+  description = "S3 prefix (bucket-name/path) where WDL workflows are stored, read permissions will be granted for this prefix"
   type        = string
-  default     = ""
 }
 
 variable "stage_memory_defaults" {


### PR DESCRIPTION
These variables should not be set to an empty string. The caller must set them to a meaningful value. Leaving them as empty strings will cause a successful deployment but errors at runtime.