### PR TITLE
S3 upload max retries 10

### DIFF
--- a/miniwdl-plugins/s3upload/miniwdl_s3upload.py
+++ b/miniwdl-plugins/s3upload/miniwdl_s3upload.py
@@ -281,7 +281,10 @@ _s3parcp_lock = threading.Lock()
 
 def s3cp(logger, fn, s3uri):
     with _s3parcp_lock:
-        cmd = ["s3parcp", "--checksum", fn, s3uri]
+        # when uploading many small outputs from the same pipeline you end up with a
+        #   quick intense burst of load that can bump into the S3 rate limit
+        #   allowing more retries should overcome this
+        cmd = ["s3parcp", "--checksum", "--max-retries", "10", fn, s3uri]
         logger.debug(" ".join(cmd))
         rslt = subprocess.run(cmd, stderr=subprocess.PIPE)
         if rslt.returncode != 0:

--- a/miniwdl-plugins/sfn_wdl/sfnwdl_miniwdl_plugin.py
+++ b/miniwdl-plugins/sfn_wdl/sfnwdl_miniwdl_plugin.py
@@ -68,14 +68,6 @@ def task(cfg, logger, run_id, run_dir, task, **recv):
 
     recv["container"].stderr_callback = stderr_callback
 
-    # inject command to log `aws sts get-caller-identity` to confirm AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
-    # is passed through & effective
-    if not run_id[-1].startswith("download-"):
-        recv["command"] = (
-            """aws sts get-caller-identity | jq -c '. + {message: "aws sts get-caller-identity"}' 1>&2\n\n"""
-            + recv["command"]
-        )
-
     try:
         recv = yield recv
 


### PR DESCRIPTION
Change and comment pretty much say it all on the upload max.

I am also removing this aws get caller identity thing. I am frankly unsure why it is nescessary, it should be fairly obvious if a pipeline doesn't have sufficient permissions. It requires that all pipelines have jq and the aws CLI or it prints unnecessary error messages.