### PR TITLE
Fix cron space-check script

### DIFF
--- a/terraform/modules/swipe-sfn-batch-queue/container_instance_user_data
+++ b/terraform/modules/swipe-sfn-batch-queue/container_instance_user_data
@@ -26,10 +26,9 @@ cloud-init-per once docker_options echo '{"data-root": "MINIWDL_DIR/docker"}' >>
 ##############################################
 
 echo '#!/bin/bash' > /bin/space-check
-echo '[[ $(df MINIWDL_DIR --output=avail |tail -n1) -lt 1000000 ]] && poweroff; echo system terminated due to full drive >> /dev/stderr' >> /bin/space-check
+echo '[[ $(df /mnt --output=avail |tail -n1) -lt 1000000 ]] && ( poweroff; echo system terminated due to full drive >> /dev/stderr )' >> /bin/space-check
 chmod +x /bin/space-check
 
-crontab -l > /tmp/mycron
 echo "* * * * * /bin/space-check" > /tmp/mycron
 crontab /tmp/mycron
 rm /tmp/mycron

--- a/terraform/modules/swipe-sfn-batch-queue/container_instance_user_data
+++ b/terraform/modules/swipe-sfn-batch-queue/container_instance_user_data
@@ -26,7 +26,7 @@ cloud-init-per once docker_options echo '{"data-root": "MINIWDL_DIR/docker"}' >>
 ##############################################
 
 echo '#!/bin/bash' > /bin/space-check
-echo '[[ $(df /mnt --output=avail |tail -n1) -lt 1000000 ]] && ( poweroff; echo system terminated due to full drive >> /dev/stderr )' >> /bin/space-check
+echo '[[ $(df MINIWDL_DIR --output=avail |tail -n1) -lt 1000000 ]] && ( poweroff; echo system terminated due to full drive >> /dev/stderr )' >> /bin/space-check
 chmod +x /bin/space-check
 
 echo "* * * * * /bin/space-check" > /tmp/mycron


### PR DESCRIPTION
* The space-check script hasn't been triggering on our instances because `crontab -l` exits with an error which errors out the script. 
* Given that we just overwrite the output anyway, and crontab should be empty, I removed that piece of code. Also, due to the grouping of the operators, we were always echoing to stderr