### PR TITLE
feat: allow for major version 4 with this module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
   required_providers {
     aws = {
-      version = "~> 3.28"
+      version = ">= 3.28"
     }
   }
 }


### PR DESCRIPTION
We are starting to use major version 4 of the AWS provider module in things like happy, however, are limited to major version three. This change will allow modules using this module to take advantage of newer AWS provider features without forcing others to bump their provider versions.