### PR TITLE
Fix docker clobbering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ localstack-test: image start-localstack wait-for-healthy deploy-localstack test
 image:
 	source environment.test; \
 	docker buildx build --platform linux/amd64 --cache-from ghcr.io/chanzuckerberg/swipe:latest -t ghcr.io/chanzuckerberg/swipe:$$(cat version) .
+	docker tag ghcr.io/chanzuckerberg/swipe:$$(cat version) swipe:$$(cat version)
 
 wait-for-healthy:
 	while true; do \

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ module "batch_queue" {
 }
 
 locals {
-  version = file("${path.module}/version")
+  version           = file("${path.module}/version")
   docker_image_path = var.app_name == "swipe-test" ? "swipe" : "ghcr.io/chanzuckerberg/swipe"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -44,12 +44,13 @@ module "batch_queue" {
 
 locals {
   version = file("${path.module}/version")
+  docker_image_path = var.app_name == "swipe-test" ? "swipe" : "ghcr.io/chanzuckerberg/swipe"
 }
 
 module "sfn" {
   source                        = "./terraform/modules/swipe-sfn"
   app_name                      = var.app_name
-  batch_job_docker_image        = "swipe:${chomp(local.version)}"
+  batch_job_docker_image        = "${local.docker_image_path}:${chomp(local.version)}"
   batch_spot_job_queue_arn      = module.batch_queue.batch_spot_job_queue_arn
   batch_on_demand_job_queue_arn = module.batch_queue.batch_on_demand_job_queue_arn
   miniwdl_dir                   = var.miniwdl_dir

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ locals {
 module "sfn" {
   source                        = "./terraform/modules/swipe-sfn"
   app_name                      = var.app_name
-  batch_job_docker_image        = "ghcr.io/chanzuckerberg/swipe:${chomp(local.version)}"
+  batch_job_docker_image        = "swipe:${chomp(local.version)}"
   batch_spot_job_queue_arn      = module.batch_queue.batch_spot_job_queue_arn
   batch_on_demand_job_queue_arn = module.batch_queue.batch_on_demand_job_queue_arn
   miniwdl_dir                   = var.miniwdl_dir


### PR DESCRIPTION
* A long time ago, I had this issue where the first time I ran the swipe tests, my code would work, but on subsequent runs it would not. Not only that, but the code would not work if it was in the second test to run. The problem got fixed if I incremented the version
* I think what's happening here is since we're running docker in docker, somewhere in the SWIPE job it's calling another SWIPE job, and pulls it from the github image repo, clobbering the local version of the image
* Here, I just tag a local version and pass it in if the app is in test mode